### PR TITLE
enhance dnstap plugin to support extra and disable dnstap in forward

### DIFF
--- a/plugin/dnstap/handler.go
+++ b/plugin/dnstap/handler.go
@@ -23,9 +23,9 @@ type Dnstap struct {
 }
 
 // TapMessage sends the message m to the dnstap interface.
-func (h Dnstap) TapMessage(m *tap.Message) {
+func (h Dnstap) TapMessage(m *tap.Message, extra []byte) {
 	t := tap.Dnstap_MESSAGE
-	h.io.Dnstap(&tap.Dnstap{Type: &t, Message: m, Identity: h.Identity, Version: h.Version})
+	h.io.Dnstap(&tap.Dnstap{Type: &t, Message: m, Identity: h.Identity, Version: h.Version, Extra: extra})
 }
 
 func (h Dnstap) tapQuery(w dns.ResponseWriter, query *dns.Msg, queryTime time.Time) {
@@ -38,7 +38,7 @@ func (h Dnstap) tapQuery(w dns.ResponseWriter, query *dns.Msg, queryTime time.Ti
 		q.QueryMessage = buf
 	}
 	msg.SetType(q, tap.Message_CLIENT_QUERY)
-	h.TapMessage(q)
+	h.TapMessage(q, nil)
 }
 
 // ServeDNS logs the client query and response to dnstap and passes the dnstap Context.

--- a/plugin/dnstap/writer.go
+++ b/plugin/dnstap/writer.go
@@ -35,6 +35,6 @@ func (w *ResponseWriter) WriteMsg(resp *dns.Msg) error {
 	}
 
 	msg.SetType(r, tap.Message_CLIENT_RESPONSE)
-	w.TapMessage(r)
+	w.TapMessage(r, nil)
 	return nil
 }

--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -50,6 +50,7 @@ forward FROM TO... {
     policy random|round_robin|sequential
     health_check DURATION [no_rec] [domain FQDN]
     max_concurrent MAX
+    no_dnstap
 }
 ~~~
 
@@ -95,6 +96,7 @@ forward FROM TO... {
   response does not count as a health failure. When choosing a value for **MAX**, pick a number
   at least greater than the expected *upstream query rate* * *latency* of the upstream servers.
   As an upper bound for **MAX**, consider that each concurrent query will use about 2kb of memory.
+* `no_dnstap`, Disable dnstap logging from forward plugin.
 
 Also note the TLS config is "global" for the whole forwarding proxy if you need a different
 `tls-name` for different upstreams you're out of luck.

--- a/plugin/forward/dnstap.go
+++ b/plugin/forward/dnstap.go
@@ -44,7 +44,7 @@ func toDnstap(f *Forward, host string, state request.Request, opts options, repl
 			q.QueryMessage = buf
 		}
 		msg.SetType(q, tap.Message_FORWARDER_QUERY)
-		t.TapMessage(q)
+		t.TapMessage(q, nil)
 
 		// Response
 		if reply != nil {
@@ -58,7 +58,7 @@ func toDnstap(f *Forward, host string, state request.Request, opts options, repl
 			msg.SetResponseAddress(r, ta)
 			msg.SetResponseTime(r, time.Now())
 			msg.SetType(r, tap.Message_FORWARDER_RESPONSE)
-			t.TapMessage(r)
+			t.TapMessage(r, nil)
 		}
 	}
 }

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -42,6 +42,7 @@ type Forward struct {
 	maxfails      uint32
 	expire        time.Duration
 	maxConcurrent int64
+	disableDnstap bool
 
 	opts options // also here for testing
 
@@ -68,6 +69,9 @@ func (f *Forward) SetProxy(p *Proxy) {
 
 // SetTapPlugin appends one or more dnstap plugins to the tap plugin list.
 func (f *Forward) SetTapPlugin(tapPlugin *dnstap.Dnstap) {
+	if f.disableDnstap {
+		return
+	}
 	f.tapPlugins = append(f.tapPlugins, tapPlugin)
 	if nextPlugin, ok := tapPlugin.Next.(*dnstap.Dnstap); ok {
 		f.SetTapPlugin(nextPlugin)

--- a/plugin/forward/forward_test.go
+++ b/plugin/forward/forward_test.go
@@ -30,37 +30,66 @@ func TestList(t *testing.T) {
 }
 
 func TestSetTapPlugin(t *testing.T) {
-	input := `forward . 127.0.0.1
-	dnstap /tmp/dnstap.sock full
-	dnstap tcp://example.com:6000
-	`
-	stanzas := strings.Split(input, "\n")
-	c := caddy.NewTestController("dns", strings.Join(stanzas[1:], "\n"))
-	dnstapSetup, err := caddy.DirectiveAction("dns", "dnstap")
-	if err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		name          string
+		input         string
+		disableDnstap bool
+	}{
+		{"Enable dnstap", `forward . 127.0.0.1
+		dnstap /tmp/dnstap.sock full
+		dnstap tcp://example.com:6000
+		`, false},
+		{"Disable dnstap", `forward . 127.0.0.1 {
+			no_dnstap
+		}
+		dnstap /tmp/dnstap.sock full
+		dnstap tcp://example.com:6000
+		`, true},
 	}
-	if err = dnstapSetup(c); err != nil {
-		t.Fatal(err)
-	}
-	c.Dispenser = caddyfile.NewDispenser("", strings.NewReader(stanzas[0]))
-	if err = setup(c); err != nil {
-		t.Fatal(err)
-	}
-	dnsserver.NewServer("", []*dnsserver.Config{dnsserver.GetConfig(c)})
-	f, ok := dnsserver.GetConfig(c).Handler("forward").(*Forward)
-	if !ok {
-		t.Fatal("Expected a forward plugin")
-	}
-	tap, ok := dnsserver.GetConfig(c).Handler("dnstap").(*dnstap.Dnstap)
-	if !ok {
-		t.Fatal("Expected a dnstap plugin")
-	}
-	f.SetTapPlugin(tap)
-	if len(f.tapPlugins) != 2 {
-		t.Fatalf("Expected: 2 results, got: %v", len(f.tapPlugins))
-	}
-	if f.tapPlugins[0] != tap || tap.Next != f.tapPlugins[1] {
-		t.Error("Unexpected order of dnstap plugins")
+	for _, tc := range tests {
+		stanzas := strings.Split(tc.input, "\n")
+		var dnstapStanza string
+		var fwdStanza string
+		if tc.disableDnstap {
+			dnstapStanza = strings.Join(stanzas[3:], "\n")
+			fwdStanza = strings.Join(stanzas[0:3], "\n")
+		} else {
+			dnstapStanza = strings.Join(stanzas[1:], "\n")
+			fwdStanza = stanzas[0]
+		}
+		c := caddy.NewTestController("dns", dnstapStanza)
+		dnstapSetup, err := caddy.DirectiveAction("dns", "dnstap")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err = dnstapSetup(c); err != nil {
+			t.Fatal(err)
+		}
+		c.Dispenser = caddyfile.NewDispenser("", strings.NewReader(fwdStanza))
+		if err = setup(c); err != nil {
+			t.Fatal(err)
+		}
+		dnsserver.NewServer("", []*dnsserver.Config{dnsserver.GetConfig(c)})
+		f, ok := dnsserver.GetConfig(c).Handler("forward").(*Forward)
+		if !ok {
+			t.Fatal("Expected a forward plugin")
+		}
+		tap, ok := dnsserver.GetConfig(c).Handler("dnstap").(*dnstap.Dnstap)
+		if !ok {
+			t.Fatal("Expected a dnstap plugin")
+		}
+		f.SetTapPlugin(tap)
+		if tc.disableDnstap {
+			if len(f.tapPlugins) != 0 {
+				t.Fatalf("Expected: 0 results, got: %v", len(f.tapPlugins))
+			}
+		} else {
+			if len(f.tapPlugins) != 2 {
+				t.Fatalf("Expected: 2 results, got: %v", len(f.tapPlugins))
+			}
+			if f.tapPlugins[0] != tap || tap.Next != f.tapPlugins[1] {
+				t.Error("Unexpected order of dnstap plugins")
+			}
+		}
 	}
 }

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -279,6 +279,11 @@ func parseBlock(c *caddy.Controller, f *Forward) error {
 		}
 		f.ErrLimitExceeded = errors.New("concurrent queries exceeded maximum " + c.Val())
 		f.maxConcurrent = int64(n)
+	case "no_dnstap":
+		if c.NextArg() {
+			return c.ArgErr()
+		}
+		f.disableDnstap = true
 
 	default:
 		return c.Errf("unknown property '%s'", c.Val())


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Add support for extra bytes in dnstap plugin

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
